### PR TITLE
Change main to timeline.sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bulma-timeline",
   "version": "0.0.4",
   "description": "Display a vertical timeline, in different colors, sizes, and states ",
-  "main": "index.js",
+  "main": "timeline.sass",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
The `main` entry in package.json currently points at a nonexistent `index.js` file.  Changing it to `timeline.sass` makes it possible to import the package by name without a path, similar to how the main bulma package can be consumed.